### PR TITLE
Add passes for PGO

### DIFF
--- a/src/build_clang/clang_build_stage.py
+++ b/src/build_clang/clang_build_stage.py
@@ -337,7 +337,10 @@ class ClangBuildStage:
             c_compiler, cxx_compiler = find_latest_gcc()
         else:
             assert self.prev_stage is not None
-            prev_stage_install_prefix = self.prev_stage.install_prefix
+            if self.prev_stage.lto:
+                prev_stage_install_prefix = self.build_conf.get_final_install_dir()
+            else:
+                prev_stage_install_prefix = self.prev_stage.install_prefix
             c_compiler = os.path.join(prev_stage_install_prefix, 'bin', 'clang')
             cxx_compiler = os.path.join(prev_stage_install_prefix, 'bin', 'clang++')
         assert c_compiler is not None

--- a/src/build_clang/clang_build_stage.py
+++ b/src/build_clang/clang_build_stage.py
@@ -327,7 +327,7 @@ class ClangBuildStage:
         if self.pgo_instrumentation:
             # Mostly taken from https://llvm.org/docs/HowToBuildWithPGO.html.
             # LLVM_BUILD_INSTRUMENTED=IR (build with instrumentation).
-            # LLVM_BUILD_RUNTIME=No (skip projects that have problems with profiling, which aren't
+            # LLVM_BUILD_RUNTIME=No (skip projects that have problems with profiling, which
             #     we don't care about anyways).
             # LLVM_VP_COUNTERS_PER_SITE=1024 to help address running out of counters warnings
             #     (though we seem to still get them... but the binaries are measurably faster).
@@ -454,9 +454,9 @@ class ClangBuildStage:
                     # Stage 3 (final non-LTO) builds everything and installs directly into
                     # final_install_dir (self.install_prefix for Stage 3 is final_install_dir).
                     #
-                    # Stage 4 and on (LTO) only builds clang/lld targets, but using those depends
-                    # on some of the other libraries that only Stage 3 built.
-                    # Stage 5/6 depend on functional stage 4/5 clang/lld, and we want to ultimately
+                    # Stage 4 and above (LTO stages) only builds clang/lld targets, but using those 
+                    # depends on some of the other libraries that only Stage 3 built.
+                    # Stage 5/6 depend on a working stage 4/5 clang/lld, and we want to ultimately
                     # package a toolchain with clang/lld targets from the final LTO stage.
                     if self.is_last_stage:
                         # If this is the final LTO stage, then we copy bin/ (Stage n) =>

--- a/src/build_clang/clang_builder.py
+++ b/src/build_clang/clang_builder.py
@@ -69,7 +69,7 @@ class ClangBuilder:
             last_non_lto_stage = (stage_number == NUM_NON_LTO_STAGES)
             self.stages.append(ClangBuildStage(
                 build_conf=self.build_conf,
-                stage_number=NUM_NON_LTO_STAGES + 1,
+                stage_number=stage_number,
                 prev_stage=self.last_stage(),
                 is_last_stage=last_non_lto_stage,
                 is_last_non_lto_stage=last_non_lto_stage,

--- a/src/build_clang/clang_builder.py
+++ b/src/build_clang/clang_builder.py
@@ -59,7 +59,7 @@ class ClangBuilder:
         #
         # If PGO is enabled, then instead:
         # 4b. LTO, PGO-instrumented build using stage 3 compiler, of some targets (clang/lld). These
-        #     are merged with artifacts from stage 3.
+        #     overwrite clang/lld from stage 3.
         # 5. LTO build using stage 4b compiler, of some targets (clang/lld). The artifacts are
         #    identical to stage 4a artifacts, but this also generates profile data. These are
         #    merged with artifacts from stage 3.
@@ -292,6 +292,8 @@ class ClangBuilder:
 
             self.init_stages()
 
+            # min_stage/max_stage are used primarily for debugging build code -- to allow only
+            # rebuilding certain stages rather than all stages.
             if self.args.pgo:
                 max_stage = NUM_NON_LTO_STAGES + 3
             elif self.args.lto:

--- a/src/build_clang/clang_builder.py
+++ b/src/build_clang/clang_builder.py
@@ -336,11 +336,16 @@ class ClangBuilder:
             with open(github_token_path) as github_token_file:
                 os.environ['GITHUB_TOKEN'] = github_token_file.read().strip()
 
+        release_message = 'Release %s (LTO %s, PGO %s)' % (
+            tag,
+            'enabled' if self.args.lto else 'disabled',
+            'enabled' if self.args.pgo else 'disabled')
+
         run_cmd([
             'hub',
             'release',
             'create', tag,
-            '-m', 'Release %s (LTO %s)' % (tag, 'enabled' if self.args.lto else 'disabled'),
+            '-m', release_message,
             '-a', archive_path,
             '-a', sha256sum_file_path,
             # '-t', ...

--- a/src/build_clang/clang_builder.py
+++ b/src/build_clang/clang_builder.py
@@ -55,19 +55,19 @@ class ClangBuilder:
             ))
 
         if self.args.lto:
-            self.stages.append(ClangBuildStage(
-                build_conf=self.build_conf,
-                stage_number=NUM_NON_LTO_STAGES + 1,
-                prev_stage=self.stages[-1],
-                is_last_stage=not self.args.pgo,
-                lto=True,
-            ))
-
-            if self.args.pgo:
+            if not self.args.pgo:
+                self.stages.append(ClangBuildStage(
+                    build_conf=self.build_conf,
+                    stage_number=NUM_NON_LTO_STAGES + 1,
+                    prev_stage=self.stages[-1],
+                    is_last_stage=True,
+                    lto=True,
+                ))
+            else:
                 # Instrumented stage.
                 self.stages.append(ClangBuildStage(
                     build_conf=self.build_conf,
-                    stage_number=NUM_NON_LTO_STAGES + 2,
+                    stage_number=NUM_NON_LTO_STAGES + 1,
                     prev_stage=self.stages[-1],
                     lto=True,
                     pgo_instrumentation=True,
@@ -75,14 +75,14 @@ class ClangBuilder:
                 # Profiled build of clang.
                 self.stages.append(ClangBuildStage(
                     build_conf=self.build_conf,
-                    stage_number=NUM_NON_LTO_STAGES + 3,
+                    stage_number=NUM_NON_LTO_STAGES + 2,
                     prev_stage=self.stages[-1],
                     lto=True,
                 ))
                 # PGO stage.
                 self.stages.append(ClangBuildStage(
                     build_conf=self.build_conf,
-                    stage_number=NUM_NON_LTO_STAGES + 4,
+                    stage_number=NUM_NON_LTO_STAGES + 3,
                     prev_stage=self.stages[-1],
                     is_last_stage=True,
                     lto=True,
@@ -272,10 +272,10 @@ class ClangBuilder:
             self.init_stages()
 
             effective_max_stage = self.args.max_stage
-            if self.args.lto:
-                effective_max_stage = NUM_NON_LTO_STAGES + 1
             if self.args.pgo:
                 effective_max_stage = NUM_NON_LTO_STAGES + 3
+            elif self.args.lto:
+                effective_max_stage = NUM_NON_LTO_STAGES + 1
 
             if self.args.skip_build:
                 logging.info("Skipping building any stages, --skip_build specified")

--- a/src/build_clang/cmd_line_args.py
+++ b/src/build_clang/cmd_line_args.py
@@ -155,7 +155,7 @@ def parse_args() -> Tuple[argparse.Namespace, ClangBuildConf]:
     parser = create_arg_parser()
     args = parser.parse_args()
 
-    max_allowed_stage = NUM_NON_LTO_STAGES + (4 if args.pgo else 1 if args.lto else 0)
+    max_allowed_stage = NUM_NON_LTO_STAGES + (3 if args.pgo else 1 if args.lto else 0)
 
     if not args.skip_build:
         if args.max_stage is None:


### PR DESCRIPTION
Add --pgo (on by default for LTO-enabled builds), which replaces the final LTO pass with three new passes:
1. Profiling enabled build
2. Normal LTO build using the profiled build to generate profiles
3. Final optimized build using profiles

yugabyte-db debug build (on c7a.4xlarge):

`./yb_build.sh --clean --no-ccache --skip-java daemons`
- PG make:
  - postgres_build: 53s -> 46s (-13%)
  - overall: 3m33s -> 3m24s (-4%)
- Build time:
  - real: 8m50s -> 7m49s (-12%)
  - user: 103m -> 87m39s (-16%)
- Single file compile time (catalog_manager.cc): 24.9s -> 19.7s (-21%)

yugabyte-db LTO release build (on c7a.4xlarge):

`rm -rf build/release-* && ./yb_release --build_args="--lto=full --no-ccache" --no_yugabyted_ui`
- PG make: 
  - postgres_build: 4m56s -> 4m12s (-15%)
  - overall: 7m56s -> 7m10s (-10%)
- yb-server linking: 12m17s -> 11m7s (-9%)
- Build time: 
  - real: 27m56s -> 24m57s (-11%)
  - user: 144m -> 122m25s (-15%)
 - Single file compile time (catalog_manager.cc): 33.7s -> 27.9s (-17%)

yugabyte-db-thirdparty build (on c7a.4xlarge):

`./clean_thirdparty.sh --all && time ./build_thirdparty.sh --toolchain=llvm19 --skip-sanitizers`
- real: 17m34s -> 15m51s (-10%)
- user: 53m15s -> 44m45s (-16%)