### PR TITLE
Skip building OpenMP tests

### DIFF
--- a/src/build_clang/clang_build_stage.py
+++ b/src/build_clang/clang_build_stage.py
@@ -299,6 +299,16 @@ class ClangBuildStage:
                 # We only need tests at the last stage because that's where we build clangd-indexer.
                 vars['LLVM_BUILD_TESTS'] = True
 
+            if self.should_build_openmp():
+                # LLVM 22+ currently has an issue where libomptest.so fails to link properly,
+                # because it mixes host and target libraries. For us, this means attempting to
+                # link to system C++ (libstdc++ on Linux), but also expecting _Unwind_Resume from
+                # libunwind, and failing with:
+                #   ld.lld: error: undefined symbol: _Unwind_Resume
+                # so disabling build of it.
+                # LLVM issue: https://github.com/llvm/llvm-project/issues/181599
+                vars['OPENMP_ENABLE_OMPT_TOOLS'] = False
+
             if self.lto:
                 vars.update(LLVM_ENABLE_LTO='Full')
                 vars.update(BUILD_SHARED_LIBS=False)


### PR DESCRIPTION
LLVM 22+ currently has an issue where libomptest.so fails to link properly, because it mixes host and target libraries. For us, this means attempting to link to system C++ (libstdc++ on Linux), but also expecting _Unwind_Resume from libunwind (only used by libc++), failing with:
```
ld.lld: error: undefined symbol: _Unwind_Resume
>>> referenced by OmptAsserter.cpp
>>>               openmp/tools/omptest/CMakeFiles/omptest.dir/src/OmptAsserter.cpp.o:(omptest::OmptAsserter::OmptAsserter())
>>> referenced by OmptAsserter.cpp
>>>               openmp/tools/omptest/CMakeFiles/omptest.dir/src/OmptAsserter.cpp.o:(omptest::OmptAsserter::verifyEventGroups(omptest::OmptAssertEvent const&, omptest::OmptAssertEvent const&))
>>> referenced by OmptAsserter.cpp
>>>               openmp/tools/omptest/CMakeFiles/omptest.dir/src/OmptAsserter.cpp.o:(omptest::OmptAsserter::verifyEventGroups(omptest::OmptAssertEvent const&, omptest::OmptAssertEvent const&))
>>> referenced 212 more times
```
This only affects Linux builds since this target is always disabled on non-Linux targets.

We don't actually need libomptest.so, but currently build it. Skipping the build of this target.

LLVM issue: https://github.com/llvm/llvm-project/issues/181599